### PR TITLE
Add SDL_events.h definitions

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -31,6 +31,9 @@ using System;
 using System.Runtime.InteropServices;
 #endregion
 
+/* We have lots of padding fields, which we want private */
+#pragma warning disable 0169
+
 namespace SDL2
 {
 	public static class SDL2
@@ -391,7 +394,7 @@ namespace SDL2
 			SDL_GL_SHARE_WITH_CURRENT_CONTEXT
 		}
 		
-		public enum SDL_WindowEventID
+		public enum SDL_WindowEventID : byte
 		{
 			SDL_WINDOWEVENT_NONE,
 			SDL_WINDOWEVENT_SHOWN,
@@ -436,16 +439,6 @@ namespace SDL2
 			public int h;
 			public int refresh_rate;
 			public IntPtr driverdata; // void*
-		}
-		
-		[StructLayout(LayoutKind.Sequential)]
-		public struct SDL_WindowEvent
-		{
-			public uint type;
-			public uint windowID;
-			public byte windowEvent; // event, lolC#
-			public int data1;
-			public int data2;
 		}
 		
 		/* IntPtr refers to an SDL_Window* */
@@ -2112,6 +2105,417 @@ namespace SDL2
 		/* TODO: Input Events:
 		 * http://wiki.libsdl.org/moin.fcg/APIByCategory#Input_Events
 		 */
+		#region SDL_events.h
+
+		/* General keyboard/mouse state definitions. */
+		public const byte SDL_PRESSED =		0;
+		public const byte SDL_RELEASED =	1;
+
+		/* The types of events that can be delivered. */
+		public enum SDL_EventType : uint
+		{
+			SDL_FIRSTEVENT =		0,
+
+			/* Application events */
+			SDL_QUIT = 			0x100,
+
+			/* Window events */
+			SDL_WINDOWEVENT = 		0x200,
+			SDL_SYSWMEVENT,
+			
+			/* Keyboard events */
+			SDL_KEYDOWN = 			0x300,
+			SDL_KEYUP,
+			SDL_TEXTEDITING,
+			SDL_TEXTINPUT,
+
+			/* Mouse events */
+			SDL_MOUSEMOTION = 		0x400,
+			SDL_MOUSEBUTTONDOWN,
+			SDL_MOUSEBUTTONUP,
+			SDL_MOUSEWHEEL,
+
+			/* Joystick events */
+			SDL_JOYAXISMOTION =		0x600,
+			SDL_JOYBALLMOTION,
+			SDL_JOYHATMOTION,
+			SDL_JOYBUTTONDOWN,
+			SDL_JOYBUTTONUP,
+			SDL_JOYDEVICEADDED,
+			SDL_JOYDEVICEREMOVED,
+
+			/* Game controller events */
+			SDL_CONTROLLERAXISMOTION = 	0x650,
+			SDL_CONTROLLERBUTTONDOWN,
+			SDL_CONTROLLERBUTTONUP,
+			SDL_CONTROLLERDEVICEADDED,
+			SDL_CONTROLLERDEVICEREMOVED,
+			SDL_CONTROLLERDEVICEREMAPPED,
+
+			/* Touch events */
+			SDL_FINGERDOWN = 		0x700,
+			SDL_FINGERUP,
+			SDL_FINGERMOTION,
+
+			/* Gesture events */
+			SDL_DOLLARGESTURE =		0x800,
+			SDL_DOLLARRECORD,
+			SDL_MULTIGESTURE,
+
+			/* Clipboard events */
+			SDL_CLIPBOARDUPDATE =		0x900,
+
+			/* Drag and drop events */
+			SDL_DROPFILE =			0x1000,
+
+			/* Events SDL_USEREVENT through SDL_LASTEVENT are for
+			 * your use, and should be allocated with
+			 * SDL_RegisterEvents()
+			 */
+			SDL_USEREVENT =			0x8000,
+
+			/* The last event, used for bouding arrays. */
+			SDL_LASTEVENT =			0xFFFF
+		}
+
+		/* Fields shared by every event */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_GenericEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+		}
+
+		/* Window state change event data (event.window.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_WindowEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public SDL_WindowEventID windowEvent; // event, lolC#
+			byte padding1;
+			byte padding2;
+			byte padding3;
+			public Int32 data1;
+			public Int32 data2;
+		}
+		
+		/* Keyboard button event structure (event.key.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_KeyboardEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public byte state;
+			public byte repeat; /* non-zero if this is a repeat */
+			byte padding2;
+			byte padding3;
+			// TODO: SDL_Keysym struct.
+		}
+
+		//TODO: SDL_Text*Event (need to work out char[] in C#)
+
+		/* Mouse motion event structure (event.motion.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_MouseMotionEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public UInt32 which;
+			public byte state; /* bitmask of buttons */
+			byte padding1;
+			byte padding2;
+			byte padding3;
+			public Int32 x;
+			public Int32 y;
+			public Int32 xrel;
+			public Int32 yrel;
+		}
+
+		/* Mouse button event structure (event.button.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_MouseButtonEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public UInt32 which;
+			public byte button; /* button id */
+			public byte state; /* SDL_PRESSED or SDL_RELEASED */
+			byte padding1;
+			byte padding2;
+			public Int32 x;
+			public Int32 y;
+		}
+
+		/* Mouse wheel event structure (event.wheel.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_MouseWheelEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public UInt32 which;
+			public Int32 x; /* amount scrolled horizontally */
+			public Int32 y; /* amount scrolled vertically */
+		}
+
+		/* Joystick axis motion event structure (event.jaxis.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_JoyAxisEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte axis;
+			byte padding1;
+			byte padding2;
+			byte padding3;
+			public Int16 axisValue; /* value, lolC# */
+			public UInt16 padding4;
+		}
+
+		/* Joystick trackball motion event structure (event.jball.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_JoyBallEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte ball;
+			byte padding1;
+			byte padding2;
+			byte padding3;
+			public Int16 xrel;
+			public Int16 yrel;
+		}
+
+		/* Joystick hat position change event struct (event.jhat.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_JoyHatEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte hat; /* index of the hat */
+			public byte hatValue; /* value, lolC# */
+			byte padding1;
+			byte padding2;
+		}
+
+		/* Joystick button event structure (event.jbutton.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_JoyButtonEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte button;
+			public byte state; /* SDL_PRESSED or SDL_RELEASED */
+			byte padding1;
+			byte padding2;
+		}
+
+		/* Joystick device event structure (event.jdevice.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_JoyDeviceEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+		}
+
+		/* Game controller axis motion event (event.caxis.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_ControllerAxisEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte axis;
+			byte padding1;
+			byte padding2;
+			byte padding3;
+			public Int16 axisValue; /* value, lolC# */
+			UInt16 padding4;
+		}
+
+		/* Game controller button event (event.cbutton.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_ControllerButtonEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* SDL_JoystickID */
+			public byte button;
+			public byte state;
+			byte padding1;
+			byte padding2;
+		}
+
+		/* Game controller device event (event.cdevice.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_ControllerDeviceEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public Int32 which; /* joystick id for ADDED, else
+					       instance id */
+		}
+
+
+		// TODO: Touch Finger events, Gesture Events
+
+		/* File open request by system (event.drop.*), disabled by
+		 * default
+		 */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_DropEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public IntPtr file; /* char* filename, to be freed */
+		}
+
+		/* The "quit requested" event */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_QuitEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+		}
+
+		/* A user defined event (event.user.*) */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_UserEvent
+		{
+			public UInt32 type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			public Int32 code;
+			public IntPtr data1; /* user-defined */
+			public IntPtr data2; /* user-defined */
+		}
+
+		/* A video driver dependent event (event.syswm.*), disabled */
+		[StructLayout(LayoutKind.Sequential)]
+		public struct SDL_SysWMEvent
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public IntPtr msg; /* SDL_SysWMmsg*, system-dependent*/
+		}
+
+		/* General event structure */
+		// C# doesn't do unions, so we do this ugly thing. */
+		[StructLayout(LayoutKind.Explicit)]
+		public struct SDL_Event
+		{
+			[FieldOffset(0)]
+			public SDL_EventType type;
+			[FieldOffset(0)]
+			public SDL_WindowEvent window;
+			[FieldOffset(0)]
+			public SDL_KeyboardEvent key;
+			//TODO: TextEditingEvent, TextInputEvent
+			[FieldOffset(0)]
+			public SDL_MouseMotionEvent motion;
+			[FieldOffset(0)]
+			public SDL_MouseButtonEvent button;
+			[FieldOffset(0)]
+			public SDL_MouseWheelEvent wheel;
+			[FieldOffset(0)]
+			public SDL_JoyAxisEvent jaxis;
+			[FieldOffset(0)]
+			public SDL_JoyBallEvent jball;
+			[FieldOffset(0)]
+			public SDL_JoyHatEvent jhat;
+			[FieldOffset(0)]
+			public SDL_JoyButtonEvent jbutton;
+			[FieldOffset(0)]
+			public SDL_JoyDeviceEvent jdevice;
+			[FieldOffset(0)]
+			public SDL_ControllerAxisEvent caxis;
+			[FieldOffset(0)]
+			public SDL_ControllerButtonEvent cbutton;
+			[FieldOffset(0)]
+			public SDL_ControllerDeviceEvent cdevice;
+			[FieldOffset(0)]
+			public SDL_QuitEvent quit;
+			[FieldOffset(0)]
+			public SDL_UserEvent user;
+			[FieldOffset(0)]
+			public SDL_SysWMEvent syswm;
+			//TODO: Touch, Gesture events
+			[FieldOffset(0)]
+			public SDL_DropEvent drop;
+		}
+
+		/* Pump the event loop, getting events from the input devices*/
+		[DllImport(nativeLibName)]
+		public static extern void SDL_PumpEvents();
+
+		public enum SDL_eventaction
+		{
+			SDL_ADDEVENT,
+			SDL_PEEKEVENT,
+			SDL_GETEVENT
+		}
+
+		//TODO: SDL_PeepEvents
+
+		/* Checks to see if certain events are in the event queue */
+		[DllImport(nativeLibName)]
+		public static extern SDL_bool SDL_HasEvent(SDL_EventType type);
+		//TODO: SDL_HasEvents
+
+		/* Clears events from the event queue */
+		[DllImport(nativeLibName)]
+		public static extern void SDL_FlushEvent(SDL_EventType type);
+		//TODO: SDL_FlushEvents
+
+		/* Polls for currently pending events */
+		[DllImport(nativeLibName)]
+		public static extern int SDL_PollEvent(out SDL_Event _event);
+
+		/* Waits indefinitely for the next event */
+		[DllImport(nativeLibName)]
+		public static extern int SDL_WaitEvent(out SDL_Event _event);
+
+		/* Waits until the specified timeout (in ms) for the next event
+		 */
+		[DllImport(nativeLibName)]
+		public static extern int SDL_WaitEventTimeout(out SDL_Event _event, int timeout);
+		
+		/* Add an event to the event queue */
+		[DllImport(nativeLibName)]
+		public static extern int SDL_PushEvent(ref SDL_Event _event);
+
+		//TODO: All of the event filter stuff.
+
+		/* These are for SDL_EventState() */
+		public const int SDL_QUERY = 		-1;
+		public const int SDL_IGNORE = 		0;
+		public const int SDL_DISABLE =		0;
+		public const int SDL_ENABLE = 		1;
+
+		/* This function allows you to enable/disable certain events */
+		[DllImport(nativeLibName)]
+		public static extern byte SDL_EventState(SDL_EventType type, int state);
+
+		/* Get the state of an event */
+		public static byte SDL_GetEventState(SDL_EventType type)
+		{
+			return SDL_EventState(type, SDL_QUERY);
+		}
+
+		/* Allocate a set of user-defined events */
+		[DllImport(nativeLibName)]
+		public static extern UInt32 SDL_RegisterEvents(int numevents);
+		#endregion
 		
 		/* TODO: Force Feedback:
 		 * http://wiki.libsdl.org/moin.fcg/APIByCategory#Force_Feedback
@@ -2122,3 +2526,5 @@ namespace SDL2
 		 */
 	}
 }
+
+#pragma warning restore 0169


### PR DESCRIPTION
Phew!

This is the first revision of the events stuff. It compiles, but I haven't tried running anything against it yet. It's also (mostly) documented, which is nice. There are a couple of changes elsewhere in the file to get things working properly: hopefully nothing too distressing.

I've got most of SDL_events.h here. There are a few events missing (Text events, Touch events and Gesture events) and a couple of functions (mostly relating to Event Filters, and I'm deathly afraid of trying to get function pointers working).

The SDL_Keysym struct also needs implementing, but that can come with the keyboard stuff, I guess.

-- David
