### PR TITLE
SDL_keyboard.h + small fixes.

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -2217,7 +2217,7 @@ namespace SDL2
 			public byte repeat; /* non-zero if this is a repeat */
 			byte padding2;
 			byte padding3;
-			// TODO: SDL_Keysym struct.
+			public SDL_Keysym keysym;
 		}
 
 		//TODO: SDL_Text*Event (need to work out char[] in C#)


### PR DESCRIPTION
This finishes the Keyboard category, as well as fixes a couple of minor things (C# wants enums with bitfields to have the [Flags] annotation). Woo!
