### PR TITLE
Changed text input events to byte, added joystick background hint

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -145,6 +145,8 @@ namespace SDL2
 			"SDL_XINPUT_ENABLED";
 		public const string SDL_HINT_GAMECONTROLLERCONFIG =
 			"SDL_GAMECONTROLLERCONFIG";
+		public const string SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS =
+			"SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS";
 		public const string SDL_HINT_ALLOW_TOPMOST =
 			"SDL_ALLOW_TOPMOST";
 		
@@ -2447,7 +2449,7 @@ namespace SDL2
 			public SDL_EventType type;
 			public UInt32 timestamp;
 			public UInt32 windowID;
-			public fixed char text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
+			public fixed byte text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
 			public Int32 start;
 			public Int32 length;
 		}
@@ -2458,7 +2460,7 @@ namespace SDL2
 			public SDL_EventType type;
 			public UInt32 timestamp;
 			public UInt32 windowID;
-			public fixed char text[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+			public fixed byte text[SDL_TEXTINPUTEVENT_TEXT_SIZE];
 		}
 
 		/* Mouse motion event structure (event.motion.*) */


### PR DESCRIPTION
Just a small change to text events from char to byte since they're UTF8 and need to be converted manually by the consumer. Also added the hint that enables background joystick events.
