### PR TITLE
 Issue #32: Added overload for SDL_RenderCopy method

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1247,15 +1247,42 @@ namespace SDL2
 			ref SDL_Rect dstrect
 		);
 
-        /* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
-        [DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int SDL_RenderCopy(
-            IntPtr renderer,
-            IntPtr texture,
-            IntPtr srcrect,
-            ref SDL_Rect dstrect
-        );
-		
+		/* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+		/* internally, this function contains logic to use default values when source
+		and destination rectangles are passed as NULL */
+		/* this overload allows for IntPtr.Zero (null) to be passed for source rectangle */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_RenderCopy(
+			IntPtr renderer,
+			IntPtr texture,
+			IntPtr srcrect,
+			ref SDL_Rect dstrect
+		);
+
+		/* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+		/* internally, this function contains logic to use default values when source
+		and destination rectangles are passed as NULL */
+		/* this overload allows for IntPtr.Zero (null) to be passed for destination rectangle */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_RenderCopy(
+			IntPtr renderer,
+			IntPtr texture,
+			ref SDL_Rect srcrect,
+			IntPtr dstrect
+		);
+
+		/* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
+		/* internally, this function contains logic to use default values when source
+		and destination rectangles are passed as NULL */
+		/* this overload allows for IntPtr.Zero (null) to be passed for both rectangles */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_RenderCopy(
+			IntPtr renderer,
+			IntPtr texture,
+			IntPtr srcrect,
+			IntPtr dstrect
+		);
+
 		/* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_RenderCopyEx(


### PR DESCRIPTION
Overload to allow SourceRectangle to be passed as an IntPtr. This allows developers to pass IntPtr.Zero to take advantage of internal SDL default values for null rectangles.

Issue #32 
