### PR TITLE
Adding methods to map to SDL_Delay and SDL_GetTicks in SDL_systimer.h

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4602,6 +4602,21 @@ namespace SDL2
 		public static extern void SDL_UnlockAudioDevice(uint dev);
 		
 		#endregion
+
+		#region SDL_systimer.h
+
+		/* system timers rely on different OS mechanisms depending on which
+		 * OS the library is compiled against */
+
+		/* delays the thread's processing based on the milliseconds parameter */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void SDL_Delay(UInt32 ms);
+
+		/* returns the milliseconds that have passed since SDL was initialized */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt32 SDL_GetTicks();
+
+		#endregion
 	}
 }
 


### PR DESCRIPTION
Querying and controlling the SDL timers are a key part of maintaining proper frame rates. These methods will help with creating a proper game loop.

Internally, SDL implements systimers differently depending on the OS. I've only tested these methods on Windows.
