### PR TITLE
Added binding to SDL_GetSystemRAM() in SDL_cpuinfo.h

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -3794,7 +3794,7 @@ namespace SDL2
 		}
 
 		#endregion
-		
+
 		#region SDL_keycode.h
 
 		public const int SDLK_SCANCODE_MASK = (1 << 30);


### PR DESCRIPTION
Works without any errors (doesn't require initing any SDL subsystems either). However, this function always returns 0 on my machine. I tried calling it in native code as well and it returned 0 as well, so it's not a problem with the binding.
