### PR TITLE
Bind touch API, adjustments to config

### DIFF
--- a/SDL2#.dll.config
+++ b/SDL2#.dll.config
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<dllmap dll="SDL2.dll" os="windows" target="SDL2.dll"/>
-	<dllmap dll="SDL2.dll" os="osx" target="SDL2.framework/SDL2"/>
+	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
 	<dllmap dll="SDL2.dll" os="linux" target="libSDL2-2.0.so.0"/>
 
 	<dllmap dll="SDL2_image.dll" os="windows" target="SDL2_image.dll"/>
-	<dllmap dll="SDL2_image.dll" os="osx" target="SDL2_image.framework/SDL2_image"/>
+	<dllmap dll="SDL2_image.dll" os="osx" target="libSDL2_image-2.0.0.dylib"/>
 	<dllmap dll="SDL2_image.dll" os="linux" target="libSDL2_image-2.0.so.0"/>
 
 	<dllmap dll="SDL2_mixer.dll" os="windows" target="SDL2_mixer.dll"/>
-	<dllmap dll="SDL2_mixer.dll" os="osx" target="SDL2_mixer.framework/SDL2_mixer"/>
+	<dllmap dll="SDL2_mixer.dll" os="osx" target="libSDL2_mixer-2.0.0.dylib"/>
 	<dllmap dll="SDL2_mixer.dll" os="linux" target="libSDL2_mixer-2.0.so.0"/>
 
 	<dllmap dll="SDL2_ttf.dll" os="windows" target="SDL2_ttf.dll"/>
-	<dllmap dll="SDL2_ttf.dll" os="osx" target="SDL2_ttf.framework/SDL2_ttf"/>
+	<dllmap dll="SDL2_ttf.dll" os="osx" target="libSDL2_ttf-2.0.0.dylib"/>
 	<dllmap dll="SDL2_ttf.dll" os="linux" target="libSDL2_ttf-2.0.so.0"/>
 
-	<dllmap dll="opengl32.dll" os="windows" target="opengl32.dll"/>
-	<dllmap dll="opengl32.dll" os="osx" target="OpenGL.framework/OpenGL"/>
-	<dllmap dll="opengl32.dll" os="linux" target="libGL.so.1"/>
-
 	<dllmap dll="openal32.dll" os="windows" target="openal32.dll"/>
-    <dllmap dll="openal32.dll" os="osx" target="OpenAL.framework/OpenAL"/>
+	<dllmap dll="openal32.dll" os="osx" target="libopenal.1.dylib"/>
 	<dllmap dll="openal32.dll" os="linux" target="libopenal.so.1"/>
 </configuration>


### PR DESCRIPTION
The project I'm working on currently involves using the touch API on linux, so I went ahead and bound it. Also, while testing on OS X, I was having trouble resolving some of the dllmaps, so I changed them to use the frameworks mechanism instead. The official SDL2 binaries for OS X are provided as frameworks, so this way probably reduces friction for users. A dllmap for OpenGL also seemed to be missing, so I added that.
