### PR TITLE
.NET doesn't use dllmaps

### DIFF
--- a/SDL2-CS.dll.config
+++ b/SDL2-CS.dll.config
@@ -16,7 +16,7 @@
 	<dllmap dll="SDL2_ttf.dll" os="osx" target="libSDL2_ttf-2.0.0.dylib"/>
 	<dllmap dll="SDL2_ttf.dll" os="linux" target="libSDL2_ttf-2.0.so.0"/>
 
-	<dllmap dll="openal32.dll" os="windows" target="soft_oal.dll"/>
-	<dllmap dll="openal32.dll" os="osx" target="libopenal.1.dylib"/>
-	<dllmap dll="openal32.dll" os="linux" target="libopenal.so.1"/>
+	<dllmap dll="soft_oal.dll" os="windows" target="soft_oal.dll"/>
+	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib"/>
+	<dllmap dll="soft_oal.dll" os="linux" target="libopenal.so.1"/>
 </configuration>

--- a/src/MiniTK/Audio/AudioCapture.cs
+++ b/src/MiniTK/Audio/AudioCapture.cs
@@ -80,7 +80,7 @@ namespace OpenTK.Audio
         public AudioCapture(string deviceName, int frequency, ALFormat sampleFormat, int bufferSize)
         {
             if (!AudioDeviceEnumerator.IsOpenALSupported)
-                throw new DllNotFoundException("openal32.dll");
+                throw new DllNotFoundException("soft_oal.dll");
             if (frequency <= 0)
                 throw new ArgumentOutOfRangeException("frequency");
             if (bufferSize <= 0)

--- a/src/MiniTK/Audio/AudioContext.cs
+++ b/src/MiniTK/Audio/AudioContext.cs
@@ -252,7 +252,7 @@ namespace OpenTK.Audio
         void CreateContext(string device, int freq, int refresh, bool sync, bool enableEfx, MaxAuxiliarySends efxAuxiliarySends)
         {
             if (!AudioDeviceEnumerator.IsOpenALSupported)
-                throw new DllNotFoundException("openal32.dll");
+                throw new DllNotFoundException("soft_oal.dll");
 
             if (AudioDeviceEnumerator.Version == AudioDeviceEnumerator.AlcVersion.Alc1_1 && AudioDeviceEnumerator.AvailablePlaybackDevices.Count == 0)    // Alc 1.0 does not support device enumeration.
                 throw new NotSupportedException("No audio hardware is available.");

--- a/src/MiniTK/Audio/OpenAL/AL/AL.cs
+++ b/src/MiniTK/Audio/OpenAL/AL/AL.cs
@@ -76,7 +76,7 @@ namespace OpenTK.Audio.OpenAL
 
         #region Constants
 
-        internal const string Lib = "openal32.dll";
+        internal const string Lib = "soft_oal.dll";
         internal const CallingConvention Style = CallingConvention.Cdecl;
 
         #endregion Constants


### PR DESCRIPTION
Microsoft's .NET doesn't know dllmaps, so "soft_oal.dll" needs to be used everywhere instead of "openal32.dll", or it will only work on Mono.
