### PR TITLE
Fix SDL_GetKeyFromScancode signature.

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4219,7 +4219,7 @@ namespace SDL2
 		 * with the current keyboard layout.
 		 */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void SDL_GetKeyFromScancode(SDL_Scancode scancode);
+		public static extern SDL_Keycode SDL_GetKeyFromScancode(SDL_Scancode scancode);
 
 		/* Get the scancode for the given keycode */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Edited SDL_GetKeyFromScancode function signature to match SDL2 http://wiki.libsdl.org/SDL_GetKeyFromScancode.
