### PR TITLE
Added bindings for SDL_PowerState and SDL_GetPowerInfo

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -6012,6 +6012,38 @@ namespace SDL2
 
 		#endregion
 
+		#region SDL_power.h
+
+		/// <summary>
+		/// The basic state for the system's power supply.
+		/// </summary>
+		public enum SDL_PowerState
+		{
+			SDL_POWERSTATE_UNKNOWN = 0,
+			SDL_POWERSTATE_ON_BATTERY,
+			SDL_POWERSTATE_NO_BATTERY,
+			SDL_POWERSTATE_CHARGING,
+			SDL_POWERSTATE_CHARGED
+		}
+
+		/// <summary>
+		/// Get the current power supply details.
+		/// </summary>
+		/// <param name="secs">Seconds of battery life left. You can pass a NULL here if
+		/// you don't care. Will return -1 if we can't determine a
+		/// value, or we're not running on a battery.</param>
+		/// <param name="pct">Percentage of battery life left, between 0 and 100. You can
+		/// pass a NULL here if you don't care. Will return -1 if we
+		/// can't determine a value, or we're not running on a battery.</param>
+		/// <returns>The state of the battery (if any).</returns>
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_PowerState SDL_GetPowerInfo(
+			out int secs,
+			out int pct
+		);
+
+		#endregion
+
 		#region SDL_cpuinfo.h
 
 		/// <summary>


### PR DESCRIPTION
I needed these for a project, so I added bindings for them. Tested and working. The documenation is copied verbatin from SDL_power.h in SDL 2.0.4

While .NET does offer alternate ways to access this information, the methods to do so are in the System.Windows.Forms namespace, which is a heavy dependency to add for such a small feature.