### PR TITLE
add SDL_UpdateTexture overload

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -2404,6 +2404,15 @@ namespace SDL2
 			IntPtr pixels,
 			int pitch
 		);
+		
+		/* texture refers to an SDL_Texture* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_UpdateTexture(
+			IntPtr texture,
+			IntPtr rect,
+			IntPtr pixels,
+			int pitch
+		);
 
 		/* renderer refers to an SDL_Renderer* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Added an overload for SDL_UpdateTexture so that you can pass a null reference, which is allowed
by the SDL2 spec. Similar pattern already exists for SDL_RenderCopy