### PR TITLE
overload openaudio to allow null

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -5850,6 +5850,12 @@ namespace SDL2
 			ref SDL_AudioSpec desired,
 			out SDL_AudioSpec obtained
 		);
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_OpenAudio(
+			ref SDL_AudioSpec desired,
+			IntPtr obtained
+		);
 
 		/* uint refers to an SDL_AudioDeviceID */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Adds an overload to SDL_OpenAudio so that you can pass IntPtr.Zero for the obtained parameter, as allowed by the SDL2 spec.