### PR TITLE
When a null C# string is passed to UTF8_ToNative(), return a null pointer instead of an empty C string.

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -45,8 +45,15 @@ namespace SDL2
 
 		internal static byte[] UTF8_ToNative(string s)
 		{
-			// Add a null terminator. That's kind of it... :/
-			return System.Text.Encoding.UTF8.GetBytes(s + '\0');
+			if (s != null)
+			{
+				// Add a null terminator. That's kind of it... :/
+				return System.Text.Encoding.UTF8.GetBytes(s + '\0');
+			}
+			else
+			{
+				return null;
+			}
 		}
 
 		internal static unsafe string UTF8_ToManaged(IntPtr s, bool freePtr = false)


### PR DESCRIPTION
Fixes issue #125.