### PR TITLE
Add overload to SDL_GL_SetAttribute which accepts the SDL_GLprofile enum to prevent having to cast

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1431,6 +1431,13 @@ namespace SDL2
 			SDL_GLattr attr,
 			int value
 		);
+		
+		public static int SDL_GL_SetAttribute(
+			SDL_GLattr attr,
+			SDL_GLprofile profile
+		) {
+			return SDL_GL_SetAttribute(attr, (int)profile);
+		}
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_GL_SetSwapInterval(int interval);


### PR DESCRIPTION
Add overload to SDL_GL_SetAttribute which accepts the SDL_GLprofile enum to prevent having to cast.

Before:
```csharp
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL_GL_CONTEXT_PROFILE_CORE);
```

After:
```csharp
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
```

I've got `using static`(s) at the top so the code looks more C like.