### PR TITLE
Add SDL_UpdateYUVTexture

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -2374,6 +2374,20 @@ namespace SDL2
 			IntPtr pixels,
 			int pitch
 		);
+		
+		/* texture refers to an SDL_Texture* */
+		/* Available in 2.0.1 or higher */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_UpdateYUVTexture(
+			IntPtr texture,
+			ref SDL_Rect rect,
+			IntPtr yPlane,
+			int yPitch,
+			IntPtr uPlane,
+			int uPitch,
+			IntPtr vPlane,
+			int vPitch
+		);
 
 		/* renderer refers to an SDL_Renderer* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
As I didn't find a particular reason for not implementing it, I added the YUV specific UpdateYUVTexture function, available since SDL2 v2.0.1 (https://wiki.libsdl.org/SDL_UpdateYUVTexture)