### PR TITLE
Build in a release configuration before packaging.

### DIFF
--- a/gitlab-ci/SDL2-CS.nuspec
+++ b/gitlab-ci/SDL2-CS.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SDL2-CS-Rolling</id>
-    <version>%version%</version>
+    <version>2000.1.1</version>
     <authors>flibitijibibo</authors>
     <owners>beannaich</owners>
     <licenseUrl>https://github.com/flibitijibibo/SDL2-CS/blob/master/LICENSE</licenseUrl>

--- a/gitlab-ci/build-net461.sh
+++ b/gitlab-ci/build-net461.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-msbuild /p:Configuration=Debug SDL2-CS.csproj
-
+msbuild /p:Configuration=Release SDL2-CS.csproj

--- a/gitlab-ci/build-netcore.sh
+++ b/gitlab-ci/build-netcore.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-dotnet build SDL2-CS.Core.csproj
-
+dotnet build -c Release SDL2-CS.Core.csproj

--- a/gitlab-ci/deploy.sh
+++ b/gitlab-ci/deploy.sh
@@ -7,4 +7,3 @@ nuget setApiKey $NUGET_API_KEY -verbosity quiet
 for package in `find *.nupkg`; do
   nuget push $package -source https://nuget.org/
 done
-

--- a/gitlab-ci/package.sh
+++ b/gitlab-ci/package.sh
@@ -6,7 +6,4 @@ version=`date +"%Y.%m.%d"`
 
 nuspec="gitlab-ci/SDL2-CS.nuspec"
 
-sed -i -e "s/%version%/$version/g" $nuspec
-
-nuget pack $nuspec
-
+nuget pack $nuspec -Version $version


### PR DESCRIPTION
Noticed the builds were `Debug`, so I changed that to `Release` and was also able to remove `sed` from the package script :tada: 