### PR TITLE
[WIP] SDLRWopsStreamWrapper

### DIFF
--- a/SDL2-CS.Core.csproj
+++ b/SDL2-CS.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Platforms>x64</Platforms>
@@ -15,6 +15,7 @@
 		<Compile Include="src\SDL2_image.cs" />
 		<Compile Include="src\SDL2_mixer.cs" />
 		<Compile Include="src\SDL2_ttf.cs" />
+		<Compile Include="src\SDLRWopsStreamWrapper.cs" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="SDL2-CS.dll.config">

--- a/SDL2-CS.csproj
+++ b/SDL2-CS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,6 +80,7 @@
     <Compile Include="src\SDL2_image.cs" />
     <Compile Include="src\SDL2_mixer.cs" />
     <Compile Include="src\SDL2_ttf.cs" />
+    <Compile Include="src\SDLRWopsStreamWrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="SDL2-CS.dll.config">

--- a/src/SDLRWopsStreamWrapper.cs
+++ b/src/SDLRWopsStreamWrapper.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Snowball.Platforms
+{
+    public class SDLRWopsStreamWrapper : IDisposable
+    {
+        public const int RW_SEEK_SET = 0;
+        public const int RW_SEEK_CUR = 1;
+        public const int RW_SEEK_END = 2;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_RWops
+        {
+            public IntPtr size;
+            public IntPtr seek;
+            public IntPtr read;
+            public IntPtr write;
+            public IntPtr close;
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate long SizeFunc(IntPtr context);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate long SeekFunc(
+                IntPtr context,
+                long offset,
+                int whence
+            );
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate IntPtr ReadFunc(
+                IntPtr context,
+                IntPtr ptr,
+                IntPtr size,
+                IntPtr num
+            );
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate IntPtr WriteFunc(
+                IntPtr context,
+                IntPtr ptr,
+                IntPtr size,
+                IntPtr num
+            );
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int CloseFunc(IntPtr context);
+        }
+
+        [DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr SDL_AllocRW();
+
+        [DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SDL_FreeRW(IntPtr area);
+
+        private static readonly SDL_RWops.SizeFunc sizeFunc = StaticSize;
+        private static readonly SDL_RWops.SeekFunc seekFunc = StaticSeek;
+        private static readonly SDL_RWops.ReadFunc readFunc = StaticRead;
+        private static readonly SDL_RWops.WriteFunc writeFunc = StaticWrite;
+        private static readonly SDL_RWops.CloseFunc closeFunc = StaticClose;
+
+        private static readonly IntPtr sizePtr = Marshal.GetFunctionPointerForDelegate(sizeFunc);
+        private static readonly IntPtr seekPtr = Marshal.GetFunctionPointerForDelegate(seekFunc);
+        private static readonly IntPtr readPtr = Marshal.GetFunctionPointerForDelegate(readFunc);
+        private static readonly IntPtr writePtr = Marshal.GetFunctionPointerForDelegate(writeFunc);
+        private static readonly IntPtr closePtr = Marshal.GetFunctionPointerForDelegate(closeFunc);
+
+        private static ConcurrentDictionary<IntPtr, SDLRWopsStreamWrapper> streams = new ConcurrentDictionary<IntPtr, SDLRWopsStreamWrapper>();
+
+        private readonly Stream _stream;
+        private IntPtr _rwops;
+
+        public SDLRWopsStreamWrapper(Stream stream)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+            _rwops = SDL_AllocRW();
+            unsafe
+            {
+                SDL_RWops* rwopsPtr = (SDL_RWops*)_rwops;
+                rwopsPtr->size = sizePtr;
+                rwopsPtr->seek = seekPtr;
+                rwopsPtr->read = readPtr;
+                rwopsPtr->write = writePtr;
+                rwopsPtr->close = closePtr;
+            }
+
+            streams.TryAdd(_rwops, this);
+        }
+
+        public static implicit operator IntPtr(SDLRWopsStreamWrapper streamWrapper) => streamWrapper._rwops;
+
+        public void Dispose()
+        {
+            if (_rwops != IntPtr.Zero)
+            {
+                SDL_FreeRW(_rwops);
+            }
+        }
+
+        private static long StaticSize(IntPtr context)
+        {
+            if (streams.TryGetValue(context, out var stream))
+                return stream.Size();
+
+            return -1;
+        }
+
+        private long Size()
+        {
+            return _stream.Length;
+        }
+
+        private static long StaticSeek(IntPtr context, long offset, int whence)
+        {
+            if (streams.TryGetValue(context, out var stream))
+                return stream.Seek(offset, whence);
+
+            return -1;
+        }
+
+        private long Seek(long offset, int whence)
+        {
+            long result;
+
+            switch (whence)
+            {
+                case RW_SEEK_SET:
+                    result = _stream.Seek(offset, SeekOrigin.Begin);
+                    break;
+
+                case RW_SEEK_CUR:
+                    result = _stream.Seek(offset, SeekOrigin.Current);
+                    break;
+
+                case RW_SEEK_END:
+                    result = _stream.Seek(offset, SeekOrigin.End);
+                    break;
+
+                default:
+                    result = -1;
+                    break;
+            }
+
+            return result;
+        }
+
+        private static IntPtr StaticRead(IntPtr context, IntPtr ptr, IntPtr size, IntPtr num)
+        {
+            if (streams.TryGetValue(context, out var stream))
+                return stream.Read(ptr, size, num);
+
+            return IntPtr.Zero;
+        }
+
+        private IntPtr Read(IntPtr ptr, IntPtr size, IntPtr num)
+        {
+            int length = size.ToInt32() * num.ToInt32();
+            var buffer = new byte[length];
+
+            length = _stream.Read(buffer, 0, length);
+
+#if NETSTANDARD2_0
+            unsafe
+            {
+                fixed (void* bufferPtr = buffer)
+                {
+                    Buffer.MemoryCopy(bufferPtr, (void*)ptr, length, length);
+                }
+            }
+#else
+            Marshal.Copy(buffer, 0, ptr, length);
+#endif
+
+            return (IntPtr)length;
+        }
+
+        private static IntPtr StaticWrite(IntPtr context, IntPtr ptr, IntPtr size, IntPtr num)
+        {
+            if (streams.TryGetValue(context, out var stream))
+                return stream.Write(ptr, size, num);
+
+            return IntPtr.Zero;
+        }
+
+        private IntPtr Write(IntPtr ptr, IntPtr size, IntPtr num)
+        {
+            int length = size.ToInt32() * num.ToInt32();
+            var buffer = new byte[length];
+
+#if NETSTANDARD2_0
+            unsafe
+            {
+                fixed (void* bufferPtr = buffer)
+                {
+
+                    Buffer.MemoryCopy(ptr.ToPointer(), bufferPtr, length, length);
+                }
+            }
+#else
+            Marshal.Copy(ptr, buffer, 0, length);
+#endif
+
+            return (IntPtr)length;
+        }
+
+        private static int StaticClose(IntPtr context)
+        {
+            if (streams.TryGetValue(context, out var stream))
+                return stream.Close();
+
+            return 0;
+        }
+
+        private int Close()
+        {
+            SDL_FreeRW(_rwops);
+            _rwops = IntPtr.Zero;
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
I would like there to be some standard way of working with SDLRWops and .NET streams. Building on the work from FNA and the FakeRWops implementation there I implemented my own version. Example usage is as follows:

```csharp
using (var streamWrapper = new SDLRWopsStreamWrapper(stream))
                surface = IMG_Load_RW(streamWrapper, 1);
```
I don't consider this pull request to be ready but I'd like to get the conversation started hence the [WIP] tag.

**Notes:**
- In the FakeRWops there is a GetTemp() method. I decided against using this for multithreaded reasons and I would also like to use ArrayPool<T>.Rent for the NETSTANDARD path if possible. (https://docs.microsoft.com/de-de/dotnet/api/system.buffers.arraypool-1.rent?view=netstandard-2.1&viewFallbackFrom=netstandard-2.0)
- I only tested the code in the NETSTANDARD path as of yet.