### PR TITLE
SDL_Vulkan_CreateSurface should use ulong

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1895,7 +1895,7 @@ namespace SDL2
 		public static extern SDL_bool SDL_Vulkan_CreateSurface(
 			IntPtr window,
 			IntPtr instance,
-			out IntPtr surface
+			out ulong surface
 		);
 
 		/* window refers to an SDL_Window*.


### PR DESCRIPTION
`VkSurfaceKHR` is defined by the macro `VK_DEFINE_NON_DISPATCHABLE_HANDLE`. This means, at least in the .NET world, that it's a ulong, not an IntPtr ([per the spec](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_DEFINE_NON_DISPATCHABLE_HANDLE.html)). This fixes a stack imbalance when using `SDL_Vulkan_CreateSurface`.