### PR TITLE
Drop events are actually enabled by default

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4355,7 +4355,7 @@ namespace SDL2
 			public float y;
 		}
 
-		/* File open request by system (event.drop.*), disabled by
+		/* File open request by system (event.drop.*), enabled by
 		 * default
 		 */
 		[StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
This simply updates the comment, seeing as the functionality was already added.

I checked both with my system package's native library and with FNA's native library archive, in both cases the event is triggered by default.
Hmm, that and the [documentation](https://wiki.libsdl.org/SDL_DropEvent?highlight=%28%5CbCategoryStruct%5Cb%29%7C%28CategoryEvents%29#Remarks) also states that:

> SDL_DropEvent is a member of the SDL_Event union and is used when an event of type SDL_DROPFILE, SDL_DROPTEXT, SDL_DROPBEGIN, or SDL_DROPCOMPLETE is reported. You would access it through the event's drop field.
>
>These events are enabled by default. You can disable it with SDL_EventState(). 