### PR TITLE
Extensions, changes to SDL_Text(Input|Editing)Event and various SDL_RWops changes

### DIFF
--- a/SDL2-CS.csproj
+++ b/SDL2-CS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -76,6 +76,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <Compile Include="src\Extensions.cs" />
     <Compile Include="src\SDL2.cs" />
     <Compile Include="src\SDL2_image.cs" />
     <Compile Include="src\SDL2_mixer.cs" />
@@ -88,5 +89,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
   </ItemGroup>
 </Project>

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,0 +1,225 @@
+﻿#region License
+/* SDL2# - C# Wrapper for SDL2
+ *
+ * Copyright (c) 2013-2016 Ethan Lee.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using SDL2;
+using static SDL2.SDL;
+#endregion
+
+namespace SDL2
+{
+	public static class SDL2Extensions
+	{
+		public static bool ToBool(
+			this SDL_bool @this)
+		{
+			return (@this == SDL_bool.SDL_TRUE);
+		}
+
+		public static SDL_bool ToSDLBool(
+			this bool @this)
+		{
+			return @this ? SDL_bool.SDL_TRUE : SDL_bool.SDL_FALSE;
+		}
+
+		public static SDL_Point ToSDLPoint(
+			this Point point)
+		{
+			SDL_Point p = new SDL_Point();
+
+			p.x = point.X;
+			p.y = point.Y;
+
+			return p;
+		}
+
+		public static Point ToPoint(
+			this SDL_Point point)
+		{
+			return new Point(point.x, point.y);
+		}
+
+		public static SDL_FPoint ToSDLFPoint(
+			this PointF point)
+		{
+			SDL_FPoint p = new SDL_FPoint();
+
+			p.x = point.X;
+			p.y = point.Y;
+
+			return p;
+		}
+
+		public static PointF ToPointF(
+			this SDL_FPoint point)
+		{
+			return new PointF(point.x, point.y);
+		}
+
+		public static SDL_Rect ToSDLRect(
+			this Rectangle rect)
+		{
+			SDL_Rect r = new SDL_Rect();
+
+			r.x = rect.X;
+			r.y = rect.Y;
+			r.w = rect.Width;
+			r.h = rect.Height;
+
+			return r;
+		}
+
+		public static Rectangle ToRectangle(
+			this SDL_Rect rect)
+		{
+			return new Rectangle(rect.x, rect.y, rect.w, rect.h);
+		}
+
+		public static SDL_FRect ToSDLFRect(
+			this RectangleF rect)
+		{
+			SDL_FRect r = new SDL_FRect();
+
+			r.x = rect.X;
+			r.y = rect.Y;
+			r.w = rect.Width;
+			r.h = rect.Height;
+
+			return r;
+		}
+
+		public static RectangleF ToRectangleF(
+			this SDL_FRect rect)
+		{
+			return new RectangleF(rect.x, rect.y, rect.w, rect.h);
+		}
+
+		public static Color ToColor(
+			this SDL_Color color)
+		{
+			return Color.FromArgb(color.a, color.r, color.g, color.b);
+		}
+
+		public static SDL_Color ToSDLColor(
+			this Color color)
+		{
+			SDL_Color result = new SDL_Color();
+
+			result.r = color.R;
+			result.g = color.G;
+			result.b = color.B;
+			result.a = color.A;
+
+			return result;
+		}
+
+		public static uint ToSDLPixel(
+			this Color color,
+			IntPtr surface)
+		{
+			uint pixel = 0;
+
+#if UNSAFE
+			unsafe
+			{
+				pixel = 
+					SDL_MapRGBA(
+						((SDL_Surface*)surface.ToPointer())->format,
+						color.R,
+						color.G,
+						color.B,
+						color.A);
+			}
+#else
+			SDL_Surface surf = new SDL_Surface();
+			Marshal.PtrToStructure(surface, surf);
+			pixel = color.ToSDLPixel(ref surf);
+#endif
+
+			return pixel;
+		}
+
+		public static uint ToSDLPixel(
+			this Color color,
+			ref SDL_Surface surface)
+		{
+			return SDL_MapRGBA(
+						surface.format,
+						color.R,
+						color.G,
+						color.B,
+						color.A);
+		}
+
+		public static Color ToColorFromSDLPixel(
+			this uint pixel,
+			IntPtr surface)
+		{
+			Color result = Color.Black;
+
+#if UNSAFE
+			unsafe
+			{
+				SDL_GetRGBA(
+					pixel,
+					((SDL_Surface*)surface.ToPointer())->format,
+					out byte r,
+					out byte g,
+					out byte b,
+					out byte a);
+
+				result = Color.FromArgb(a, r, g, b);
+			}
+#else
+			SDL_Surface surf = new SDL_Surface();
+			Marshal.PtrToStructure(surface, surf);
+			result = pixel.ToColorFromSDLPixel(ref surf);
+#endif
+
+			return result;
+		}
+
+		public static Color ToColorFromSDLPixel(
+			this uint pixel,
+			ref SDL_Surface surface)
+		{
+			SDL_GetRGBA(
+				pixel,
+				surface.format,
+				out byte r,
+				out byte g,
+				out byte b,
+				out byte a);
+
+			return Color.FromArgb(a, r, g, b);
+		}
+	}
+}

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -164,6 +164,10 @@ namespace SDL2
 		/* mem refers to a void*, IntPtr to an SDL_RWops* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern IntPtr SDL_RWFromMem(IntPtr mem, int size);
+		
+		/* mem refers to a const void*, IntPtr to an SDL_RWops* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_RWFromConstMem(IntPtr mem, int size);
 
 		/* Only available in SDL 2.0.10 or higher. */
 		/* context refers to an SDL_RWops* */

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -135,6 +135,10 @@ namespace SDL2
 
 		#region SDL_rwops.h
 
+		public const int RW_SEEK_SET = 0;
+		public const int RW_SEEK_CUR = 1;
+		public const int RW_SEEK_END = 2;
+
 		/* Note about SDL2# and Internal RWops:
 		 * These functions are currently not supported for public use.
 		 * They are only meant to be used internally in functions marked with

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -139,11 +139,59 @@ namespace SDL2
 		public const int RW_SEEK_CUR = 1;
 		public const int RW_SEEK_END = 2;
 
-		/* Note about SDL2# and Internal RWops:
-		 * These functions are currently not supported for public use.
-		 * They are only meant to be used internally in functions marked with
-		 * the phrase "THIS IS AN RWops FUNCTION!"
-		 */
+		public const UInt32 SDL_RWOPS_UNKNOWN	= 0; /* Unknown stream type */
+		public const UInt32 SDL_RWOPS_WINFILE	= 1; /* Win32 file */
+		public const UInt32 SDL_RWOPS_STDFILE	= 2; /* Stdio file */
+		public const UInt32 SDL_RWOPS_JNIFILE	= 3; /* Android asset */
+		public const UInt32 SDL_RWOPS_MEMORY	= 4; /* Memory stream */
+		public const UInt32 SDL_RWOPS_MEMORY_RO = 5; /* Read-Only memory stream */
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate long SDLRWopsSizeCallback(
+			IntPtr context);
+		
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate long SDLRWopsSeekCallback(
+			IntPtr context,
+			long offset,
+			int whence);
+		
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate uint SDLRWopsReadCallback(
+			IntPtr context,
+			IntPtr ptr,
+			uint size,
+			uint maxnum);
+		
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate uint SDLRWopsWriteCallback(
+			IntPtr context,
+			IntPtr ptr,
+			uint size,
+			uint num);
+		
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		public delegate int SDLRWopsCloseCallback(
+			IntPtr context);
+		
+		[StructLayout(LayoutKind.Sequential)]
+		public unsafe struct SDL_RWops
+		{
+			public IntPtr size;
+			public IntPtr seek;
+			public IntPtr read;
+			public IntPtr write;
+			public IntPtr close;
+
+			public UInt32 type;
+
+			/*
+			 * This isn't the full structure since
+			 * the native SDL_RWops contains a hidden union full of
+			 * internal information and platform-specific stuff depending
+			 * on what conditions the native library was built with
+			 */
+		}
 
 		/* IntPtr refers to an SDL_RWops* */
 		[DllImport(nativeLibName, EntryPoint = "SDL_RWFromFile", CallingConvention = CallingConvention.Cdecl)]
@@ -151,7 +199,7 @@ namespace SDL2
 			byte[] file,
 			byte[] mode
 		);
-		internal static IntPtr INTERNAL_SDL_RWFromFile(
+		public static IntPtr SDL_RWFromFile(
 			string file,
 			string mode
 		) {
@@ -160,10 +208,19 @@ namespace SDL2
 				UTF8_ToNative(mode)
 			);
 		}
+		
+		
+		/* IntPtr refers to an SDL_RWops* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_AllocRW();
 
-		/* These are the public RWops functions. They should be used by
-		 * functions marked with the phrase "THIS IS A PUBLIC RWops FUNCTION!"
-		 */
+		/* area refers to an SDL_RWops* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void SDL_FreeRW(IntPtr area);
+
+		/* fp refers to a void* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_RWFromFP(IntPtr fp, SDL_bool autoclose);
 
 		/* mem refers to a void*, IntPtr to an SDL_RWops* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
@@ -211,6 +268,52 @@ namespace SDL2
 			uint size,
 			uint maxnum
 		);
+
+		/* Read endian functions */
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern byte SDL_ReadU8(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt16 SDL_ReadLE16(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt16 SDL_ReadBE16(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt32 SDL_ReadLE32(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt32 SDL_ReadBE32(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt64 SDL_ReadLE64(IntPtr src);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt64 SDL_ReadBE64(IntPtr src);
+
+		/* Write endian functions */
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteU8(IntPtr dst, byte value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteLE16(IntPtr dst, UInt16 value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteBE16(IntPtr dst, UInt16 value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteLE32(IntPtr dst, UInt32 value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteBE32(IntPtr dst, UInt32 value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteLE64(IntPtr dst, UInt64 value);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern uint SDL_WriteBE64(IntPtr dst, UInt64 value);
 
 		/* Only available in SDL 2.0.10 or higher. */
 		/* context refers to an SDL_RWops* */
@@ -3780,7 +3883,7 @@ namespace SDL2
 		);
 		public static IntPtr SDL_LoadBMP(string file)
 		{
-			IntPtr rwops = INTERNAL_SDL_RWFromFile(file, "rb");
+			IntPtr rwops = SDL_RWFromFile(file, "rb");
 			return INTERNAL_SDL_LoadBMP_RW(rwops, 1);
 		}
 
@@ -3817,7 +3920,7 @@ namespace SDL2
 		);
 		public static int SDL_SaveBMP(IntPtr surface, string file)
 		{
-			IntPtr rwops = INTERNAL_SDL_RWFromFile(file, "wb");
+			IntPtr rwops = SDL_RWFromFile(file, "wb");
 			return INTERNAL_SDL_SaveBMP_RW(surface, rwops, 1);
 		}
 
@@ -4123,12 +4226,36 @@ namespace SDL2
 		}
 
 		[StructLayout(LayoutKind.Sequential)]
+		public unsafe struct SDL_TextEditingEvent_SAFE
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			[MarshalAs(UnmanagedType.ByValArray, 
+				SizeConst = SDL_TEXTEDITINGEVENT_TEXT_SIZE)]
+			public byte[] text;
+			public Int32 start;
+			public Int32 length;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
 		public unsafe struct SDL_TextInputEvent
 		{
 			public SDL_EventType type;
 			public UInt32 timestamp;
 			public UInt32 windowID;
 			public fixed byte text[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public unsafe struct SDL_TextInputEvent_SAFE
+		{
+			public SDL_EventType type;
+			public UInt32 timestamp;
+			public UInt32 windowID;
+			[MarshalAs(UnmanagedType.ByValArray, 
+				SizeConst = SDL_TEXTINPUTEVENT_TEXT_SIZE)]
+			public byte[] text;
 		}
 
 // Ignore private members used for padding in this struct
@@ -5888,7 +6015,7 @@ namespace SDL2
 		);
 		public static int SDL_GameControllerAddMappingsFromFile(string file)
 		{
-			IntPtr rwops = INTERNAL_SDL_RWFromFile(file, "rb");
+			IntPtr rwops = SDL_RWFromFile(file, "rb");
 			return INTERNAL_SDL_GameControllerAddMappingsFromRW(rwops, 1);
 		}
 
@@ -6749,7 +6876,7 @@ namespace SDL2
 			out uint audio_len
 		) {
 			SDL_AudioSpec result;
-			IntPtr rwops = INTERNAL_SDL_RWFromFile(file, "rb");
+			IntPtr rwops = SDL_RWFromFile(file, "rb");
 			IntPtr result_ptr = INTERNAL_SDL_LoadWAV_RW(
 				rwops,
 				1,

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4223,17 +4223,39 @@ namespace SDL2
 			public fixed byte text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
 			public Int32 start;
 			public Int32 length;
+
+			public SDL_TextEditingEvent_SAFE ToSafe()
+			{
+				SDL_TextEditingEvent_SAFE result =
+					default(SDL_TextEditingEvent_SAFE);
+
+				GCHandle handle = GCHandle.Alloc(this, GCHandleType.Pinned);
+
+				try
+				{
+					IntPtr ptr = handle.AddrOfPinnedObject();
+					result = (SDL_TextEditingEvent_SAFE)
+						Marshal.PtrToStructure(
+							ptr, typeof(SDL_TextEditingEvent_SAFE));
+				}
+				finally
+				{
+					handle.Free();
+				}
+
+				return result;
+			}
 		}
 
-		[StructLayout(LayoutKind.Sequential)]
-		public unsafe struct SDL_TextEditingEvent_SAFE
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		public struct SDL_TextEditingEvent_SAFE
 		{
 			public SDL_EventType type;
 			public UInt32 timestamp;
 			public UInt32 windowID;
-			[MarshalAs(UnmanagedType.ByValArray, 
+			[MarshalAs(UnmanagedType.ByValTStr, 
 				SizeConst = SDL_TEXTEDITINGEVENT_TEXT_SIZE)]
-			public byte[] text;
+			public string text;
 			public Int32 start;
 			public Int32 length;
 		}
@@ -4245,17 +4267,39 @@ namespace SDL2
 			public UInt32 timestamp;
 			public UInt32 windowID;
 			public fixed byte text[SDL_TEXTINPUTEVENT_TEXT_SIZE];
+
+			public SDL_TextInputEvent_SAFE ToSafe()
+			{
+				SDL_TextInputEvent_SAFE result =
+					default(SDL_TextInputEvent_SAFE);
+
+				GCHandle handle = GCHandle.Alloc(this, GCHandleType.Pinned);
+
+				try
+				{
+					IntPtr ptr = handle.AddrOfPinnedObject();
+					result = (SDL_TextInputEvent_SAFE)
+						Marshal.PtrToStructure(
+							ptr, typeof(SDL_TextInputEvent_SAFE));
+				}
+				finally
+				{
+					handle.Free();
+				}
+
+				return result;
+			}
 		}
 
-		[StructLayout(LayoutKind.Sequential)]
-		public unsafe struct SDL_TextInputEvent_SAFE
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		public struct SDL_TextInputEvent_SAFE
 		{
 			public SDL_EventType type;
 			public UInt32 timestamp;
 			public UInt32 windowID;
-			[MarshalAs(UnmanagedType.ByValArray, 
+			[MarshalAs(UnmanagedType.ByValTStr, 
 				SizeConst = SDL_TEXTINPUTEVENT_TEXT_SIZE)]
-			public byte[] text;
+			public string text;
 		}
 
 // Ignore private members used for padding in this struct

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -7245,6 +7245,48 @@ namespace SDL2
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_GetCPUCount();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_GetCPUCacheLineSize();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasRDTSC();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasAltiVec();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasMMX();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_Has3DNow();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasSSE();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasSSE2();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasSSE3();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasSSE41();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasSSE42();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasAVX();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasAVX2();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasAVX512F();
+		
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern SDL_bool SDL_HasNEON();
 
 		/* Only available in 2.0.1 */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/SDL2_mixer.cs
+++ b/src/SDL2_mixer.cs
@@ -184,7 +184,7 @@ namespace SDL2
 		/* This is an RWops macro in the C header. */
 		public static IntPtr Mix_LoadWAV(string file)
 		{
-			IntPtr rwops = SDL.INTERNAL_SDL_RWFromFile(file, "rb");
+			IntPtr rwops = SDL.SDL_RWFromFile(file, "rb");
 			return Mix_LoadWAV_RW(rwops, 1);
 		}
 


### PR DESCRIPTION
This may or may not be your cup of tea but here it is for your consideration.

First set of changes are the addition of some extension methods to allow easy conversion of common .NET structures and SDL structures.
If you are writing a strict 1:1 port of SDL's header files then you may not want these bells and whistles handy as they are.
Here are some examples of the extension methods, but are not limited to these:

- SDL_FPoint.ToPointF
- PointF.ToSDLFPoint
- SDL_Rect.ToRectangle
- Rectangle.ToSDLRect
- Color.ToSDLColor
- SDL_Color.ToColor


Second set of changes has to do with the fact that SDL_TextInputEvent and SDL_TextEditingEvent both use a fixed byte buffer.
When compiling with Unsafe code enabled this is not much of a problem, however if you're not compiling as unsafe then there is no way to access the .text fields (of type byte*) to the best of my knowledge as the compiler will spit out an error if you try to touch it.
My solution to this issue is to add a second set of SDL_TextInputEvent_SAFE and SDL_TextEditingEvent_SAFE structures that can be created with the .ToSafe() method in the regular structures.
The .ToSafe() method uses Marshal to pin the original structure in memory and then uses PtrToStructure to convert it into a _SAFE structure where the .text field can be easily accessed as a string.
I've tried this from an application both with and without unsafe code enabled and it works fine either way.


Third set makes changes to the SDL_RWops functionality.
It partially adds the SDL_RWops structure for using with Marshal or unsafe code.
It also adds various callback signatures for SDL_RWops, and some missing constants and related functions.
I'm currently writing an object oriented wrapper around SDL2-CS for my personal use, and whoever else wants to use it, and one of the classes I implemented was [ReadWriteOperation](https://github.com/JamesK89/SDLWrapper/blob/master/ReadWriteOperation.cs) that makes use of these changes to allow C# code to interact with native SDL file operations or to act as a bridge between System.IO.Stream and SDL_RWop.


Feel free to make use of this code, change it or discard it. Thoughts would be appreciated either way.