### PR TITLE
Added additional RWops functions and partial SDL_RWops structure.

### DIFF
--- a/src/SDL2_mixer.cs
+++ b/src/SDL2_mixer.cs
@@ -184,7 +184,7 @@ namespace SDL2
 		/* This is an RWops macro in the C header. */
 		public static IntPtr Mix_LoadWAV(string file)
 		{
-			IntPtr rwops = SDL.INTERNAL_SDL_RWFromFile(file, "rb");
+			IntPtr rwops = SDL.SDL_RWFromFile(file, "rb");
 			return Mix_LoadWAV_RW(rwops, 1);
 		}
 


### PR DESCRIPTION
As requested here are the RWops changes independently.
It adds some missing constants and functions.
The SDL_RWops structure was also partially added for use with Marshal or unsafe code along with callback signatures used by said structure.
It also exposes SDL_RWFromFile as public now, so several places in the code that referenced INTERNAL_SDL_RWFromFile(string, string) where changed to reflect that.

These changes were made as part of my personal SDLWrapper project when implementing the [ReadWriteOperation](https://github.com/JamesK89/SDLWrapper/blob/master/ReadWriteOperation.cs) class. I only mention it in case you need an example of how I used it in practice.