### PR TITLE
Add SDL_SysWMinfo.info.win.hinstance

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -7223,6 +7223,7 @@ namespace SDL2
 		{
 			public IntPtr window; // Refers to an HWND
 			public IntPtr hdc; // Refers to an HDC
+			public IntPtr hinstance; // Refers to an HINSTANCE
 		}
 
 		[StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
What the titled said. This field was [added in SDL 2.0.6](https://wiki.libsdl.org/SDL_SysWMinfo).
HINSTANCE is needed for creating vulkan surfaces on Windows in [Veldrid](https://github.com/mellinoe/veldrid).