### PR TITLE
Add padding to SDL_Event

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4822,7 +4822,7 @@ namespace SDL2
 		/* General event structure */
 		// C# doesn't do unions, so we do this ugly thing. */
 		[StructLayout(LayoutKind.Explicit)]
-		public struct SDL_Event
+		public unsafe struct SDL_Event
 		{
 			[FieldOffset(0)]
 			public SDL_EventType type;
@@ -4878,6 +4878,8 @@ namespace SDL2
 			public SDL_DollarGestureEvent dgesture;
 			[FieldOffset(0)]
 			public SDL_DropEvent drop;
+			[FieldOffset(0)]
+			private fixed byte padding[56];
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
Per [this comment](https://hg.libsdl.org/SDL/file/355a4f94a782/include/SDL_events.h#l588), the `SDL_Event` struct needs to be padded out to 56 bytes.