### PR TITLE
Fix buffer overflow.

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -68,11 +68,7 @@ namespace SDL2
 		{
 			if (str == null)
 			{
-				if (bufferSize > 0)
-				{
-					buffer[0] = 0;
-				}
-				return buffer;
+				return (byte*) 0;
 			}
 			fixed (char* strPtr = str)
 			{


### PR DESCRIPTION
We need to not send garbage down to SDL when we get a null string.  The buffer would be sized 0, so it wouldn't be converted to an empty string like line 73 is trying to do.  The SDL API is designed to accept null as a valid argument, so best to pass it along preserving the API contract.