### PR TITLE
Added IMG_GetError and IMG_SetError

### DIFF
--- a/src/SDL2_image.cs
+++ b/src/SDL2_image.cs
@@ -254,6 +254,16 @@ namespace SDL2
 			int quality
 		);
 
+		public static string IMG_GetError()
+		{
+			return SDL.SDL_GetError();
+		}
+
+		public static void IMG_SetError(string fmtAndArglist)
+		{
+			SDL.SDL_SetError(fmtAndArglist);
+		}
+
 		#region Animated Image Support
 
 		/* This region is only available in 2.0.6 or higher. */


### PR DESCRIPTION
When I was trying to setup a basic example using SDL2-CS I found that SDL2_image didn't have `IMG_GetError` and `IMG_SetError`. After some digging I then found out that the `SDL2_image.h` just has:

`/* We'll use SDL for reporting errors */`
`#define IMG_SetError    SDL_SetError`
`#define IMG_GetError    SDL_GetError`

So this PR provides the same functionality by just wrapping the `SDL_GetError` and `SDL_SetError` in SDL2.cs.