### PR TITLE
Add NULL overload to SDL_SetWindowDisplayMode

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1944,6 +1944,14 @@ namespace SDL2
 		);
 
 		/* window refers to an SDL_Window* */
+		/* NULL overload - use the window's dimensions and the desktop's format and refresh rate */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_SetWindowDisplayMode(
+			IntPtr window,
+			IntPtr mode
+		);
+
+		/* window refers to an SDL_Window* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_SetWindowFullscreen(
 			IntPtr window,


### PR DESCRIPTION
The `SDL_SetWindowDisplayMode` function [can be passed in `NULL`](https://wiki.libsdl.org/SDL_SetWindowDisplayMode) instead of a `SDL_DisplayMode` reference to use the window's dimensions and the desktop's format and refresh rate.

This overload is meant to be used with `IntPtr.Zero`.