### PR TITLE
Add TTF_GetError and TTF_SetError

### DIFF
--- a/src/SDL2_ttf.cs
+++ b/src/SDL2_ttf.cs
@@ -754,6 +754,16 @@ namespace SDL2
 			ushort ch
 		);
 
+		public static string TTF_GetError()
+		{
+			return SDL.SDL_GetError();
+		}
+
+		public static void TTF_SetError(string fmtAndArglist)
+		{
+			SDL.SDL_SetError(fmtAndArglist);
+		}
+		
 		#endregion
 	}
 }


### PR DESCRIPTION
Adding some missing functions to SDL2_ttf that are just wrappers of the `SDL_GetError` and `SDL_SetError` as per the SDL_ttf header:
```
/* We'll use SDL for reporting errors */
#define TTF_SetError    SDL_SetError
#define TTF_GetError    SDL_GetError
```