### PR TITLE
Add Mix_GetError, Mix_SetError, Mix_ClearError

### DIFF
--- a/src/SDL2_mixer.cs
+++ b/src/SDL2_mixer.cs
@@ -646,6 +646,21 @@ namespace SDL2
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void Mix_CloseAudio();
 
+		public static string Mix_GetError()
+		{
+			return SDL.SDL_GetError();
+		}
+
+		public static void Mix_SetError(string fmtAndArglist)
+		{
+			SDL.SDL_SetError(fmtAndArglist);
+		}
+		
+		public static void Mix_ClearError()
+		{
+			SDL.SDL_ClearError();
+		}
+		
 		#endregion
 	}
 }


### PR DESCRIPTION
Adding `Mix_GetError`, `Mix_SetError`, `Mix_ClearError` as per the SDL_mixer header file:

/* We'll use SDL for reporting errors */
#define Mix_SetError    SDL_SetError
#define Mix_GetError    SDL_GetError
#define Mix_ClearError  SDL_ClearError