### PR TITLE
Add pointer overload for SDL_PeepEvents.

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -5444,6 +5444,15 @@ namespace SDL2
 			SDL_EventType maxType
 		);
 
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern unsafe int SDL_PeepEvents(
+			SDL_Event* events,
+			int numevents,
+			SDL_eventaction action,
+			SDL_EventType minType,
+			SDL_EventType maxType
+		);
+
 		/* Checks to see if certain events are in the event queue */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDL_bool SDL_HasEvent(SDL_EventType type);


### PR DESCRIPTION
So no kludging with an array interop.