### PR TITLE
Add `SDL_GetTouchName`

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -6508,6 +6508,16 @@ namespace SDL2
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDL_TouchDeviceType SDL_GetTouchDeviceType(Int64 touchID);
 
+		/* Only available in 2.0.22 or higher. */
+		[DllImport(nativeLibName, EntryPoint = "SDL_GetTouchName", CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr INTERNAL_SDL_GetTouchName(int index);
+
+		/* Only available in 2.0.22 or higher. */
+		public static string SDL_GetTouchName(int index)
+		{
+			return UTF8_ToManaged(INTERNAL_SDL_GetTouchName(index));
+		}
+
 		#endregion
 
 		#region SDL_joystick.h


### PR DESCRIPTION
SDL source: https://github.com/libsdl-org/SDL/blob/580d231822b20b52ce36dfc2918b691cadf5ac84/include/SDL_touch.h#L98-L104.

Uses same convention as `SDL_JoystickName` etc.:
https://github.com/flibitijibibo/SDL2-CS/blob/dd7503d2acc21e9392d65a7d1cdb2fec4df19ee9/src/SDL2.cs#L6621-L6631
