### PR TITLE
SDL_HasARMSIMD should be SDL_bool return type

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -8873,7 +8873,7 @@ namespace SDL2
 
 		/* Only available in SDL 2.0.11 or higher. */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void SDL_HasARMSIMD();
+		public static extern SDL_bool SDL_HasARMSIMD();
 
 		#endregion
 


### PR DESCRIPTION
This function should return an SDL_bool, not void per SDL wiki https://wiki.libsdl.org/SDL_HasARMSIMD. 

This will possibly have an effect on armv7 and early armv8 platforms so it's important it gets fixed.