### PR TITLE
Fix the SDL_JoystickGetAxisInitialState signature

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -6602,7 +6602,7 @@ namespace SDL2
 		public static extern SDL_bool SDL_JoystickGetAxisInitialState(
 			IntPtr joystick,
 			int axis,
-			out ushort state
+			out short state
 		);
 
 		/* joystick refers to an SDL_Joystick* */


### PR DESCRIPTION
The documentation for [SDL_JoystickGetAxisInitialState](https://wiki.libsdl.org/SDL_JoystickGetAxisInitialState) and it's implementation is using a Sint16 for the state pointer, this has for some reason been translated to a ushort in C# which transforms the negative values into positive values. This didn't seem like the intended behaviour here so this goes and fix it