### PR TITLE
Support trimming and AOT

### DIFF
--- a/SDL2-CS.Core.csproj
+++ b/SDL2-CS.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net451;netstandard2.0;net7.0</TargetFrameworks>
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/SDL2-CS.Core.csproj
+++ b/SDL2-CS.Core.csproj
@@ -9,6 +9,8 @@
 		<RootNamespace>SDL2</RootNamespace>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<IsTrimmable>true</IsTrimmable>
+		<EnableAOTAnalyzer>true</EnableAOTAnalyzer>
 	</PropertyGroup>
 	<PropertyGroup>
 		<SDLSettingsPropsFilePath>$(SolutionDir)SDL2-CS.Settings.props</SDLSettingsPropsFilePath>

--- a/SDL2-CS.Core.csproj
+++ b/SDL2-CS.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net451;netstandard2.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net40;netstandard2.0;net7.0</TargetFrameworks>
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -9,6 +9,8 @@
 		<RootNamespace>SDL2</RootNamespace>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' != 'net40' ">
 		<IsTrimmable>true</IsTrimmable>
 		<EnableAOTAnalyzer>true</EnableAOTAnalyzer>
 	</PropertyGroup>

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -29,7 +29,9 @@
 #region Using Statements
 using System;
 using System.Diagnostics;
+#if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -29,6 +29,7 @@
 #region Using Statements
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion
@@ -40,6 +41,38 @@ namespace SDL2
 		#region SDL2# Variables
 
 		private const string nativeLibName = "SDL2";
+
+		#endregion
+
+		#region Marshaling
+
+#if NET6_0_OR_GREATER
+		internal static T PtrToStructure<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(IntPtr ptr) {
+#else
+		internal static T PtrToStructure<T>(IntPtr ptr) {
+#endif
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+			return Marshal.PtrToStructure<T>(ptr);
+#else
+			return (T)Marshal.PtrToStructure(ptr, typeof(T));
+#endif
+		}
+
+		internal static T GetDelegateForFunctionPointer<T>(IntPtr ptr) where T : Delegate {
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+			return Marshal.GetDelegateForFunctionPointer<T>(ptr);
+#else
+			return (T)Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
+#endif
+		}
+
+		internal static int SizeOf<T>() {
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+			return Marshal.SizeOf<T>();
+#else
+			return Marshal.SizeOf(typeof(T));
+#endif
+		}
 
 		#endregion
 
@@ -1141,7 +1174,7 @@ namespace SDL2
 			);
 			if (result != IntPtr.Zero)
 			{
-				callback = Marshal.GetDelegateForFunctionPointer<SDL_LogOutputFunction>(
+				callback = GetDelegateForFunctionPointer<SDL_LogOutputFunction>(
 					result
 				);
 			}
@@ -1280,7 +1313,7 @@ namespace SDL2
 
 			if (messageboxdata.colorScheme != null)
 			{
-				data.colorScheme = Marshal.AllocHGlobal(Marshal.SizeOf<SDL_MessageBoxColorScheme>());
+				data.colorScheme = Marshal.AllocHGlobal(SizeOf<SDL_MessageBoxColorScheme>());
 				Marshal.StructureToPtr(messageboxdata.colorScheme.Value, data.colorScheme, false);
 			}
 
@@ -4358,7 +4391,7 @@ namespace SDL2
 		public static bool SDL_MUSTLOCK(IntPtr surface)
 		{
 			SDL_Surface sur;
-			sur = Marshal.PtrToStructure<SDL_Surface>(
+			sur = PtrToStructure<SDL_Surface>(
 				surface
 			);
 			return (sur.flags & SDL_RLEACCEL) != 0;
@@ -5518,7 +5551,7 @@ namespace SDL2
 			SDL_bool retval = SDL_GetEventFilter(out result, out userdata);
 			if (result != IntPtr.Zero)
 			{
-				filter = Marshal.GetDelegateForFunctionPointer<SDL_EventFilter>(
+				filter = GetDelegateForFunctionPointer<SDL_EventFilter>(
 					result
 				);
 			}

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1141,9 +1141,8 @@ namespace SDL2
 			);
 			if (result != IntPtr.Zero)
 			{
-				callback = (SDL_LogOutputFunction) Marshal.GetDelegateForFunctionPointer(
-					result,
-					typeof(SDL_LogOutputFunction)
+				callback = Marshal.GetDelegateForFunctionPointer<SDL_LogOutputFunction>(
+					result
 				);
 			}
 			else
@@ -5519,9 +5518,8 @@ namespace SDL2
 			SDL_bool retval = SDL_GetEventFilter(out result, out userdata);
 			if (result != IntPtr.Zero)
 			{
-				filter = (SDL_EventFilter) Marshal.GetDelegateForFunctionPointer(
-					result,
-					typeof(SDL_EventFilter)
+				filter = Marshal.GetDelegateForFunctionPointer<SDL_EventFilter>(
+					result
 				);
 			}
 			else

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1281,7 +1281,7 @@ namespace SDL2
 
 			if (messageboxdata.colorScheme != null)
 			{
-				data.colorScheme = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(SDL_MessageBoxColorScheme)));
+				data.colorScheme = Marshal.AllocHGlobal(Marshal.SizeOf<SDL_MessageBoxColorScheme>());
 				Marshal.StructureToPtr(messageboxdata.colorScheme.Value, data.colorScheme, false);
 			}
 
@@ -4359,9 +4359,8 @@ namespace SDL2
 		public static bool SDL_MUSTLOCK(IntPtr surface)
 		{
 			SDL_Surface sur;
-			sur = (SDL_Surface) Marshal.PtrToStructure(
-				surface,
-				typeof(SDL_Surface)
+			sur = Marshal.PtrToStructure<SDL_Surface>(
+				surface
 			);
 			return (sur.flags & SDL_RLEACCEL) != 0;
 		}

--- a/src/SDL2_image.cs
+++ b/src/SDL2_image.cs
@@ -74,9 +74,8 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_IMG_Linked_Version();
-			result = (SDL.SDL_version) Marshal.PtrToStructure(
-				result_ptr,
-				typeof(SDL.SDL_version)
+			result = Marshal.PtrToStructure<SDL.SDL_version>(
+				result_ptr
 			);
 			return result;
 		}

--- a/src/SDL2_image.cs
+++ b/src/SDL2_image.cs
@@ -74,7 +74,7 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_IMG_Linked_Version();
-			result = Marshal.PtrToStructure<SDL.SDL_version>(
+			result = SDL.PtrToStructure<SDL.SDL_version>(
 				result_ptr
 			);
 			return result;

--- a/src/SDL2_mixer.cs
+++ b/src/SDL2_mixer.cs
@@ -151,7 +151,7 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_MIX_Linked_Version();
-			result = Marshal.PtrToStructure<SDL.SDL_version>(
+			result = SDL.PtrToStructure<SDL.SDL_version>(
 				result_ptr
 			);
 			return result;

--- a/src/SDL2_mixer.cs
+++ b/src/SDL2_mixer.cs
@@ -151,9 +151,8 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_MIX_Linked_Version();
-			result = (SDL.SDL_version) Marshal.PtrToStructure(
-				result_ptr,
-				typeof(SDL.SDL_version)
+			result = Marshal.PtrToStructure<SDL.SDL_version>(
+				result_ptr
 			);
 			return result;
 		}

--- a/src/SDL2_ttf.cs
+++ b/src/SDL2_ttf.cs
@@ -80,7 +80,7 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_TTF_LinkedVersion();
-			result = Marshal.PtrToStructure<SDL.SDL_version>(
+			result = SDL.PtrToStructure<SDL.SDL_version>(
 				result_ptr
 			);
 			return result;

--- a/src/SDL2_ttf.cs
+++ b/src/SDL2_ttf.cs
@@ -80,9 +80,8 @@ namespace SDL2
 		{
 			SDL.SDL_version result;
 			IntPtr result_ptr = INTERNAL_TTF_LinkedVersion();
-			result = (SDL.SDL_version) Marshal.PtrToStructure(
-				result_ptr,
-				typeof(SDL.SDL_version)
+			result = Marshal.PtrToStructure<SDL.SDL_version>(
+				result_ptr
 			);
 			return result;
 		}


### PR DESCRIPTION
This PR enables the trimming and AOT analyzers, and fixes all of the corresponding warnings. There were only a few to fix, and they were all fixed by using the generic versions of some marshalling functions.

Unfortunately, those functions were introduced in .NET 4.5.1, so I had to bump the minimum framework to that. Hopefully this shouldn't cause too much of a problem, since .NET 4.0 is already long out of support.

I also added .NET 7.0 as a target framework so that AOT warnings are displayed during compilation (but that can be removed if wanted).