### PR TITLE
Publicly expose RWops functions

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -4674,15 +4674,15 @@ namespace SDL2
 		/* These are for SDL_LoadBMP, which is a macro in the SDL headers. */
 		/* IntPtr refers to an SDL_Surface* */
 		/* THIS IS AN RWops FUNCTION! */
-		[DllImport(nativeLibName, EntryPoint = "SDL_LoadBMP_RW", CallingConvention = CallingConvention.Cdecl)]
-		private static extern IntPtr INTERNAL_SDL_LoadBMP_RW(
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_LoadBMP_RW(
 			IntPtr src,
 			int freesrc
 		);
 		public static IntPtr SDL_LoadBMP(string file)
 		{
 			IntPtr rwops = SDL_RWFromFile(file, "rb");
-			return INTERNAL_SDL_LoadBMP_RW(rwops, 1);
+			return SDL_LoadBMP_RW(rwops, 1);
 		}
 
 		/* surface refers to an SDL_Surface* */
@@ -4710,8 +4710,8 @@ namespace SDL2
 		/* These are for SDL_SaveBMP, which is a macro in the SDL headers. */
 		/* IntPtr refers to an SDL_Surface* */
 		/* THIS IS AN RWops FUNCTION! */
-		[DllImport(nativeLibName, EntryPoint = "SDL_SaveBMP_RW", CallingConvention = CallingConvention.Cdecl)]
-		private static extern int INTERNAL_SDL_SaveBMP_RW(
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int SDL_SaveBMP_RW(
 			IntPtr surface,
 			IntPtr src,
 			int freesrc
@@ -4719,7 +4719,7 @@ namespace SDL2
 		public static int SDL_SaveBMP(IntPtr surface, string file)
 		{
 			IntPtr rwops = SDL_RWFromFile(file, "wb");
-			return INTERNAL_SDL_SaveBMP_RW(surface, rwops, 1);
+			return SDL_SaveBMP_RW(surface, rwops, 1);
 		}
 
 		/* surface refers to an SDL_Surface* */
@@ -8192,8 +8192,8 @@ namespace SDL2
 
 		/* audio_buf refers to a malloc()'d buffer, IntPtr to an SDL_AudioSpec* */
 		/* THIS IS AN RWops FUNCTION! */
-		[DllImport(nativeLibName, EntryPoint = "SDL_LoadWAV_RW", CallingConvention = CallingConvention.Cdecl)]
-		private static extern IntPtr INTERNAL_SDL_LoadWAV_RW(
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_LoadWAV_RW(
 			IntPtr src,
 			int freesrc,
 			out SDL_AudioSpec spec,
@@ -8207,7 +8207,7 @@ namespace SDL2
 			out uint audio_len
 		) {
 			IntPtr rwops = SDL_RWFromFile(file, "rb");
-			return INTERNAL_SDL_LoadWAV_RW(
+			return SDL_LoadWAV_RW(
 				rwops,
 				1,
 				out spec,


### PR DESCRIPTION
This small PR exposes a few RWops functions, which allows callers to load and save from memory (e.g. embedded resources).
This way we could avoid writing to a file first in order to use the currently exposed functions which only take a file path.

For example, Ryujinx is currently making use of `SDL_LoadBMP_RW()` here: [SetWindowIcon()](https://github.com/TSRBerry/Ryujinx/blob/c1a78095aa5a9a4aaff81a3489cd819f119d98b0/Ryujinx.Headless.SDL2/WindowBase.cs#L117-L143)

(I edited this in Github's online editor, so I hope I didn't miss any of them.)