### PR TITLE
Add SDL_GetWindowSizeInPixels

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -1913,6 +1913,14 @@ namespace SDL2
 			out int h
 		);
 
+		/* window refers to an SDL_Window* */
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void SDL_GetWindowSizeInPixels(
+			IntPtr window,
+			out int w,
+			out int h
+		);
+
 		/* IntPtr refers to an SDL_Surface*, window to an SDL_Window* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern IntPtr SDL_GetWindowSurface(IntPtr window);


### PR DESCRIPTION
Added `SDL_GetWindowSizeInPixels` which is available from SDL 2.26.0, as `SDL_GL/Metal/Vulkan_GetDrawableSize()` were removed from SDL's main branch: https://github.com/libsdl-org/SDL/pull/7183

Link to the SDL_video header:
https://github.com/libsdl-org/SDL/blob/05eb08053d48fea9052ad02b3d619244aeb868d3/include/SDL_video.h#L1050-L1069