### PR TITLE
Renamed extern call from RenderCopyEx to RenderCopyExF for float based parameters

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -3075,7 +3075,7 @@ namespace SDL2
 
 		/* renderer refers to an SDL_Renderer*, texture to an SDL_Texture* */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int SDL_RenderCopyEx(
+		public static extern int SDL_RenderCopyExF(
 			IntPtr renderer,
 			IntPtr texture,
 			ref SDL_Rect srcrect,

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -3091,7 +3091,7 @@ namespace SDL2
 		 * This overload allows for IntPtr.Zero (null) to be passed for srcrect.
 		 */
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int SDL_RenderCopyEx(
+		public static extern int SDL_RenderCopyExF(
 			IntPtr renderer,
 			IntPtr texture,
 			IntPtr srcrect,


### PR DESCRIPTION
Single mistake of missing "F" on a float call for RenderCopyEx

This took me 3 hours to figure out. Never expected the wrapper to be at fault.
Just in case someone is still using this library and calls this specific function